### PR TITLE
replaced deprecated pip flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         echo "This is a PYPI package."
 
         python -m pip install --upgrade pip
-        pip install cython --install-option='--no-cython-compile'
+        pip install cython --config-settings="--build-option=--no-cython-compile"
         pip install --no-cache-dir -r requirements-dev.txt
 
         if [[ ${{ inputs.invoke_lint }} = "true" ]]; then


### PR DESCRIPTION
As of `pip==23.1` [deprecation](https://github.com/pypa/pip/issues/11358) of `--insatll-options` is enforced which breaks the build. 
According to [this](https://discuss.python.org/t/explicit-optional-cythonization-via-config-setting-post-pep517-and-install-option-deprecation/25379/2) flag can be passed using `--config-settings`.